### PR TITLE
Adding arithmetic expressions and function calls

### DIFF
--- a/br.unb.cic.mcsl.tests/src/br/unb/cic/mcsl/tests/files/basicModelWithConstraintsClause.cryptsl
+++ b/br.unb.cic.mcsl.tests/src/br/unb/cic/mcsl/tests/files/basicModelWithConstraintsClause.cryptsl
@@ -11,7 +11,10 @@ ORDER
    cs | (c1, c2)*    
    
 CONSTRAINTS
-	callTo[m];
-	noCallTo[n];
-	neverTypeOf[f, java.lang.String];
-	foo in { "abc", "def" }; 
+	callTo[m]
+	noCallTo[n]
+	neverTypeOf[f, java.lang.String]
+	foo in { "abc", "def" }
+	function(text) <= doo + foo
+	part(1, "/", transformation) in {"CBC", "PCBC", "CTR", "CTS", "CFB", "OFB"} && encmode == 1
+	part(1, "/", transformation) in {algorithm}

--- a/br.unb.cic.mcsl/src/br/unb/cic/mcsl/MetaCrySL.xtext
+++ b/br.unb.cic.mcsl/src/br/unb/cic/mcsl/MetaCrySL.xtext
@@ -158,36 +158,77 @@ PrimaryExp returns EventExp
 
 ConstraintSpec: {ConstraintSpec} 'CONSTRAINTS' constraints += ConstraintsExp+;
  
-ConstraintsExp: exp = ConstraintDisjunction ";" ;
+ConstraintsExp: exp = ConstraintDisjunction;
+
+ConstraintDisjunction
+: ConstraintConjunction => ({ConstraintDisjunction.left = current} '||' right=ConstraintsExp)?	
+;
  
- ConstraintDisjunction
-  : ConstraintConjunction => ({ConstraintDisjunction.left = current} '||' right=ConstraintsExp)?	
-  ;
- 
- ConstraintConjunction:
- 	ConstraintImpliance => ({ConstraintConjunction.left = current} '&&' right=ConstraintsExp)?
- ;
+ConstraintConjunction:
+ ConstraintLessOrEqualThan => ({ConstraintConjunction.left = current} '&&' right=ConstraintsExp)?
+;
+
+ConstraintLessOrEqualThan
+: ConstraintGreaterOrEqualThan => ({ConstraintLessOrEqualThan.left = current} '<=' right=ConstraintsExp)?
+;
+
+ConstraintGreaterOrEqualThan
+: ConstraintLessThan => ({ConstraintGreaterOrEqualThan.left = current} '>=' right=ConstraintsExp)?
+;
+
+ConstraintLessThan
+: ConstraintGreaterThan => ({ConstraintLessThan.left = current} '<' right=ConstraintsExp)?
+;
+
+ConstraintGreaterThan
+: ConstraintEqual => ({ConstraintGreaterThan.left = current} '>' right=ConstraintsExp)?
+;
+
+ConstraintEqual
+: ConstraintNotEqual => ({ConstraintEqual.left = current} '==' right=ConstraintsExp)?
+;
+
+ConstraintNotEqual
+: ConstraintSum => ({ConstraintNotEqual.left = current} '!=' right=ConstraintsExp)?
+;
+
+ConstraintSum
+: ConstraintSubtraction => ({ConstraintSum.left = current} '+' right=ConstraintsExp)?
+;
+
+ConstraintSubtraction
+: ConstraintImpliance => ({ConstraintSubtraction.left = current} '-' right=ConstraintsExp)?
+;
  
  ConstraintImpliance:
  	PrimaryConstraintExp => ({ConstraintImpliance.left = current} '=>' right=ConstraintsExp)?
  ;
  
  PrimaryConstraintExp
-  : {SimpleId} id = ID 
+  : {SimpleId} id = ID
+  | {FunctionCall} methodName=ID '(' params += Foo (',' params += Foo)* ')' 
   | {NeverTypeOf} 'neverTypeOf' '[' var = ID ',' varType = JvmTypeReference ']'
   | {NoCallTo} 'noCallTo' '[' method = ID ']'
   | {CallTo} 'callTo' '[' method = ID ']'
   | {NotHardCoded} 'notHardCoded' '[' var = ID "]"
   | {Length} 'length' '[' var = ID ']'
   | {InstanceOf} 'instanceOf' '[' var = ID ',' varType = JvmTypeReference ']'
-  |	{InSet} var = ID 'in' literalSet = LiteralSet
+  |	{InSet} var = LeftSide 'in' literalSet = LiteralSet
   ;
+  
+  
+ LeftSide
+   : {SimpleId} id = ID
+   | {FunctionCall} methodName=ID '(' params += Foo (',' params += Foo)* ')' 	
+ ;
 
  LiteralSet : '{' values += Foo (',' values += Foo)* '}';
+ 
  
  Foo 
   : {IntValue} value = NUMBER 
   | {StringValue} value = STRING	
+  | {id} value = ID
   ;
  
  terminal NUMBER : ('1' .. '9')('0'..'9')*;


### PR DESCRIPTION
I'm adding the remaining arithmetic expressions. It's also possible now to add function calls as a primitive expression.

There are issues remaining with precedence laws. I would like some guidance on how to organize the grammar for expressions such as:
```
part(1, "/", transformation) in {"CBC", "PCBC", "CTR", "CTS", "CFB", "OFB"} && encmode == 1
```

My understanding is that I should treat this expression as an `AND` expression between a `inSet` expression and a `equality` expression. At the moment this implementation is throwing errors at this test:

```
java.lang.AssertionError: Unexpected errors: XtextSyntaxDiagnostic: null:19 missing EOF at '=='
```