### PR TITLE
Implementing Constraint CodeWriter

### DIFF
--- a/br.unb.cic.mcsl.tests/test-resources/cryptsl-files/testModel.mcsl
+++ b/br.unb.cic.mcsl.tests/test-resources/cryptsl-files/testModel.mcsl
@@ -25,6 +25,7 @@ CONSTRAINTS
 	notHardCoded[foo] => bar;
 	foo in {foo, bar};
 	foo in ${bar};
+	(foo + bar) in {foo, bar};
 	
 
 REQUIRES

--- a/br.unb.cic.mcsl.tests/test-resources/cryptsl-files/testModel.mcsl
+++ b/br.unb.cic.mcsl.tests/test-resources/cryptsl-files/testModel.mcsl
@@ -15,6 +15,10 @@ CONSTRAINTS
 	foo + bar => foo + bar;
 	foo => foo && bar;
 	foo => foo >= 10; 
+	foo => bar || foo + bar;
+	foo || foo + bar;
+	neverTypeOf[foo,bar] || bar;
+
 	
 
 REQUIRES

--- a/br.unb.cic.mcsl.tests/test-resources/cryptsl-files/testModel.mcsl
+++ b/br.unb.cic.mcsl.tests/test-resources/cryptsl-files/testModel.mcsl
@@ -24,6 +24,7 @@ CONSTRAINTS
 	instanceOf[foo, bar] <= foo + bar;
 	notHardCoded[foo] => bar;
 	foo in {foo, bar};
+	foo in ${bar};
 	
 
 REQUIRES

--- a/br.unb.cic.mcsl.tests/test-resources/cryptsl-files/testModel.mcsl
+++ b/br.unb.cic.mcsl.tests/test-resources/cryptsl-files/testModel.mcsl
@@ -23,6 +23,7 @@ CONSTRAINTS
 	length[foo] <= length[bar];
 	instanceOf[foo, bar] <= foo + bar;
 	notHardCoded[foo] => bar;
+	foo in {foo, bar};
 	
 
 REQUIRES

--- a/br.unb.cic.mcsl.tests/test-resources/cryptsl-files/testModel.mcsl
+++ b/br.unb.cic.mcsl.tests/test-resources/cryptsl-files/testModel.mcsl
@@ -20,7 +20,9 @@ CONSTRAINTS
 	neverTypeOf[foo,bar] || bar;
 	noCallTo[foo] => bar;
 	callTo[foo] => bar;
-
+	length[foo] <= length[bar];
+	instanceOf[foo, bar] <= foo + bar;
+	notHardCoded[foo] => bar;
 	
 
 REQUIRES

--- a/br.unb.cic.mcsl.tests/test-resources/cryptsl-files/testModel.mcsl
+++ b/br.unb.cic.mcsl.tests/test-resources/cryptsl-files/testModel.mcsl
@@ -26,6 +26,7 @@ CONSTRAINTS
 	foo in {foo, bar};
 	foo in ${bar};
 	(foo + bar) in {foo, bar};
+	foo(foo, bar) => foo + bar;
 	
 
 REQUIRES

--- a/br.unb.cic.mcsl.tests/test-resources/cryptsl-files/testModel.mcsl
+++ b/br.unb.cic.mcsl.tests/test-resources/cryptsl-files/testModel.mcsl
@@ -18,6 +18,8 @@ CONSTRAINTS
 	foo => bar || foo + bar;
 	foo || foo + bar;
 	neverTypeOf[foo,bar] || bar;
+	noCallTo[foo] => bar;
+	callTo[foo] => bar;
 
 	
 

--- a/br.unb.cic.mcsl/src/br/unb/cic/mcsl/MetaCrySL.xtext
+++ b/br.unb.cic.mcsl/src/br/unb/cic/mcsl/MetaCrySL.xtext
@@ -203,7 +203,7 @@ ArithmeticExp returns ConstraintExp
  : BasicExp ({ArithmeticExp.left = current} operator = ('+' | '-') right = BasicExp)*;
 
  BasicExp returns ConstraintExp
-  : {NeverTypeOf} 'neverTypeOf' '[' var = ID ',' varType = JvmTypeReference ']'
+  : {NeverTypeOf} 'neverTypeOf' '[' var = ID ',' varType = ID ']'
   | {NoCallTo} 'noCallTo' '[' method = ID ']'
   | {CallTo} 'callTo' '[' method = ID ']'
   | {NotHardCoded} 'notHardCoded' '[' var = ID "]"

--- a/br.unb.cic.mcsl/src/br/unb/cic/mcsl/MetaCrySL.xtext
+++ b/br.unb.cic.mcsl/src/br/unb/cic/mcsl/MetaCrySL.xtext
@@ -208,7 +208,7 @@ ArithmeticExp returns ConstraintExp
   | {CallTo} 'callTo' '[' method = ID ']'
   | {NotHardCoded} 'notHardCoded' '[' var = ID "]"
   | {Length} 'length' '[' var = ID ']'
-  | {InstanceOf} 'instanceOf' '[' var = ID ',' varType = JvmTypeReference ']'
+  | {InstanceOf} 'instanceOf' '[' var = ID ',' varType = ID ']'
   |	{InSet} left = AtomicConstraintExp 'in' literalSet = LiteralSet
   | {AtomicConstraint} exp = AtomicConstraintExp
   ;

--- a/br.unb.cic.mcsl/src/br/unb/cic/mcsl/generator/CodeWriterVisitor.xtend
+++ b/br.unb.cic.mcsl/src/br/unb/cic/mcsl/generator/CodeWriterVisitor.xtend
@@ -26,6 +26,7 @@ import br.unb.cic.mcsl.metaCrySL.impl.VariableImpl
 import br.unb.cic.mcsl.metaCrySL.MetaVariable
 import br.unb.cic.mcsl.metaCrySL.impl.MetaVariableImpl
 import br.unb.cic.mcsl.metaCrySL.impl.BracketsImpl
+import br.unb.cic.mcsl.metaCrySL.impl.FunctionCallImpl
 
 class CodeWriterVisitor extends MetaCrySLSwitch<String> {
 	
@@ -94,6 +95,7 @@ class CodeWriterVisitor extends MetaCrySLSwitch<String> {
 	def String prettyPrintAtomicConstraint(AtomicConstraint atomic) {
 		switch(atomic.exp) {
 			ValueImpl: return prettyPrintValue(atomic.exp as ValueImpl)
+			FunctionCallImpl: return prettyPrintFunctionCall(atomic.exp as FunctionCallImpl)
 		}
 		throw new RuntimeException("not supported yet " + atomic.exp)
 	}
@@ -154,7 +156,20 @@ class CodeWriterVisitor extends MetaCrySLSwitch<String> {
 				return prettyPrintBackets(exp.left as BracketsImpl) + 
 					' in ' + prettyPrintLiteralSet(exp.literalSet)
 			}
+			FunctionCallImpl: {
+				return prettyPrintFunctionCall(exp.left as FunctionCallImpl) + 
+					' in ' + prettyPrintLiteralSet(exp.literalSet)
+			}
 		}
+	}
+	
+	def String prettyPrintFunctionCall(FunctionCallImpl exp) {
+		val params = new ArrayList<String>
+		for(obj: exp.params) {
+			val el = obj as VariableImpl
+			params.add(el.varName)
+		}
+		return exp.methodName + '(' + String.join(',', params) + ')'
 	}
 	
 	/**

--- a/br.unb.cic.mcsl/src/br/unb/cic/mcsl/generator/CodeWriterVisitor.xtend
+++ b/br.unb.cic.mcsl/src/br/unb/cic/mcsl/generator/CodeWriterVisitor.xtend
@@ -25,6 +25,7 @@ import java.util.ArrayList
 import br.unb.cic.mcsl.metaCrySL.impl.VariableImpl
 import br.unb.cic.mcsl.metaCrySL.MetaVariable
 import br.unb.cic.mcsl.metaCrySL.impl.MetaVariableImpl
+import br.unb.cic.mcsl.metaCrySL.impl.BracketsImpl
 
 class CodeWriterVisitor extends MetaCrySLSwitch<String> {
 	
@@ -149,7 +150,18 @@ class CodeWriterVisitor extends MetaCrySLSwitch<String> {
 				return prettyPrintValue(exp.left as ValueImpl) + 
 					' in ' + prettyPrintLiteralSet(exp.literalSet)
 			}
+			BracketsImpl: {
+				return prettyPrintBackets(exp.left as BracketsImpl) + 
+					' in ' + prettyPrintLiteralSet(exp.literalSet)
+			}
 		}
+	}
+	
+	/**
+	 * pretty print a *Brackets* constraint
+	 */
+	def String prettyPrintBackets(BracketsImpl exp) {
+		return '(' + prettyPrint(exp.exp as ConstraintExp) + ')'
 	}
 	
 	/**

--- a/br.unb.cic.mcsl/src/br/unb/cic/mcsl/generator/CodeWriterVisitor.xtend
+++ b/br.unb.cic.mcsl/src/br/unb/cic/mcsl/generator/CodeWriterVisitor.xtend
@@ -1,7 +1,6 @@
 package br.unb.cic.mcsl.generator
 
 import br.unb.cic.mcsl.metaCrySL.ArithmeticExp
-import br.unb.cic.mcsl.metaCrySL.AtomicConstraint
 import br.unb.cic.mcsl.metaCrySL.ConstraintExp
 import br.unb.cic.mcsl.metaCrySL.ImpliesExp
 import br.unb.cic.mcsl.metaCrySL.Variable
@@ -11,6 +10,8 @@ import br.unb.cic.mcsl.metaCrySL.ConjunctionExp
 import br.unb.cic.mcsl.metaCrySL.DisjunctionExp
 import br.unb.cic.mcsl.metaCrySL.RelationalExp
 import br.unb.cic.mcsl.metaCrySL.IntValue
+import br.unb.cic.mcsl.metaCrySL.AtomicConstraint
+import br.unb.cic.mcsl.metaCrySL.NeverTypeOf
 
 class CodeWriterVisitor extends MetaCrySLSwitch<String> {
 	
@@ -26,7 +27,8 @@ class CodeWriterVisitor extends MetaCrySLSwitch<String> {
 			DisjunctionExp: return prettyPrintDisjunctionExpression(exp)
 			RelationalExp : return prettyPrintRelationalExpression(exp)
 			ArithmeticExp : return prettyPrintArithmeticExpression(exp)
-			AtomicConstraint: return prettyPrintAtomicConstraint(exp) 
+			AtomicConstraint: return prettyPrintAtomicConstraint(exp)
+			NeverTypeOf: return prettyPrintNeverTypeOf(exp)
 		}
 		throw new RuntimeException("not implemented yet " + exp)
 	}
@@ -74,6 +76,13 @@ class CodeWriterVisitor extends MetaCrySLSwitch<String> {
 			ValueImpl: return prettyPrintValue(atomic.exp as ValueImpl)
 		}
 		throw new RuntimeException("not supported yet " + atomic.exp)
+	}
+	
+	/**
+	 * pretty print an *neverTypeOf* constraint
+	 */
+	def String prettyPrintNeverTypeOf(NeverTypeOf exp) {
+		return 'neverTypeOf[' + exp.^var + ',' + exp.varType + ']' 
 	}
 	
 	/**

--- a/br.unb.cic.mcsl/src/br/unb/cic/mcsl/generator/CodeWriterVisitor.xtend
+++ b/br.unb.cic.mcsl/src/br/unb/cic/mcsl/generator/CodeWriterVisitor.xtend
@@ -17,6 +17,12 @@ import br.unb.cic.mcsl.metaCrySL.NoCallTo
 import br.unb.cic.mcsl.metaCrySL.Length
 import br.unb.cic.mcsl.metaCrySL.InstanceOf
 import br.unb.cic.mcsl.metaCrySL.NotHardCoded
+import br.unb.cic.mcsl.metaCrySL.InSet
+import br.unb.cic.mcsl.metaCrySL.LiteralSet
+import br.unb.cic.mcsl.metaCrySL.impl.LiteralSetImpl
+import br.unb.cic.mcsl.metaCrySL.impl.AtomicConstraintImpl
+import java.util.ArrayList
+import br.unb.cic.mcsl.metaCrySL.impl.VariableImpl
 
 class CodeWriterVisitor extends MetaCrySLSwitch<String> {
 	
@@ -39,6 +45,7 @@ class CodeWriterVisitor extends MetaCrySLSwitch<String> {
 			Length        : return prettyPrintLength(exp)
 			InstanceOf    : return prettyPrintInstanceOf(exp)
 			NotHardCoded  : return prettyPrintNotHardCoded(exp)
+			InSet         : return prettyPrintInSet(exp)
 		}
 		throw new RuntimeException("not implemented yet " + exp)
 	}
@@ -124,8 +131,39 @@ class CodeWriterVisitor extends MetaCrySLSwitch<String> {
 		return 'instanceOf[' + exp.^var + ',' + exp.varType + ']'
 	}
 	
+	/**
+	 * pretty print a *NotHardCoded* constraint
+	 */
 	def String prettyPrintNotHardCoded(NotHardCoded exp) {
 		return 'notHardCoded[' + exp.^var  + ']'
+	}
+	
+	/**
+	 * pretty print a *InSet* constraint
+	 */
+	def String prettyPrintInSet(InSet exp) {
+		switch(exp.left) {
+			ValueImpl: {
+				return prettyPrintValue(exp.left as ValueImpl) + 
+					' in ' + prettyPrintLiteralSet(exp.literalSet)
+			}
+		}
+	}
+	
+	/**
+	 * pretty print a *LiteralSet* constraint
+	 */
+	def String prettyPrintLiteralSet(LiteralSet exp) {
+		switch(exp) {
+			LiteralSet: {
+				val values = new ArrayList<String>
+				for(obj: exp.values) {
+					val el = obj as VariableImpl
+					values.add(el.varName)
+				}
+				return '{' + String.join(',', values) + '}'
+			}
+		}
 	}
 	
 	/**

--- a/br.unb.cic.mcsl/src/br/unb/cic/mcsl/generator/CodeWriterVisitor.xtend
+++ b/br.unb.cic.mcsl/src/br/unb/cic/mcsl/generator/CodeWriterVisitor.xtend
@@ -12,6 +12,8 @@ import br.unb.cic.mcsl.metaCrySL.RelationalExp
 import br.unb.cic.mcsl.metaCrySL.IntValue
 import br.unb.cic.mcsl.metaCrySL.AtomicConstraint
 import br.unb.cic.mcsl.metaCrySL.NeverTypeOf
+import br.unb.cic.mcsl.metaCrySL.CallTo
+import br.unb.cic.mcsl.metaCrySL.NoCallTo
 
 class CodeWriterVisitor extends MetaCrySLSwitch<String> {
 	
@@ -28,7 +30,9 @@ class CodeWriterVisitor extends MetaCrySLSwitch<String> {
 			RelationalExp : return prettyPrintRelationalExpression(exp)
 			ArithmeticExp : return prettyPrintArithmeticExpression(exp)
 			AtomicConstraint: return prettyPrintAtomicConstraint(exp)
-			NeverTypeOf: return prettyPrintNeverTypeOf(exp)
+			NeverTypeOf   : return prettyPrintNeverTypeOf(exp)
+			CallTo        : return prettyPrintCallTo(exp)
+			NoCallTo      : return prettyPrintNoCallTo(exp)
 		}
 		throw new RuntimeException("not implemented yet " + exp)
 	}
@@ -83,6 +87,21 @@ class CodeWriterVisitor extends MetaCrySLSwitch<String> {
 	 */
 	def String prettyPrintNeverTypeOf(NeverTypeOf exp) {
 		return 'neverTypeOf[' + exp.^var + ',' + exp.varType + ']' 
+	}
+	
+	
+	/**
+	 * pretty print a *CallTo* constraint
+	 */
+	def String prettyPrintCallTo(CallTo exp) {
+		return 'callTo[' + exp.method + ']'
+	}
+	
+	/**
+	 * pretty print a *NoCallTo* constraint
+	 */
+	def String prettyPrintNoCallTo(NoCallTo exp) {
+		return 'noCallTo[' + exp.method + ']'
 	}
 	
 	/**

--- a/br.unb.cic.mcsl/src/br/unb/cic/mcsl/generator/CodeWriterVisitor.xtend
+++ b/br.unb.cic.mcsl/src/br/unb/cic/mcsl/generator/CodeWriterVisitor.xtend
@@ -14,6 +14,9 @@ import br.unb.cic.mcsl.metaCrySL.AtomicConstraint
 import br.unb.cic.mcsl.metaCrySL.NeverTypeOf
 import br.unb.cic.mcsl.metaCrySL.CallTo
 import br.unb.cic.mcsl.metaCrySL.NoCallTo
+import br.unb.cic.mcsl.metaCrySL.Length
+import br.unb.cic.mcsl.metaCrySL.InstanceOf
+import br.unb.cic.mcsl.metaCrySL.NotHardCoded
 
 class CodeWriterVisitor extends MetaCrySLSwitch<String> {
 	
@@ -33,6 +36,9 @@ class CodeWriterVisitor extends MetaCrySLSwitch<String> {
 			NeverTypeOf   : return prettyPrintNeverTypeOf(exp)
 			CallTo        : return prettyPrintCallTo(exp)
 			NoCallTo      : return prettyPrintNoCallTo(exp)
+			Length        : return prettyPrintLength(exp)
+			InstanceOf    : return prettyPrintInstanceOf(exp)
+			NotHardCoded  : return prettyPrintNotHardCoded(exp)
 		}
 		throw new RuntimeException("not implemented yet " + exp)
 	}
@@ -102,6 +108,24 @@ class CodeWriterVisitor extends MetaCrySLSwitch<String> {
 	 */
 	def String prettyPrintNoCallTo(NoCallTo exp) {
 		return 'noCallTo[' + exp.method + ']'
+	}
+	
+	/**
+	 * pretty print a *Length* constraint
+	 */
+	def String prettyPrintLength(Length exp) {
+		return 'length[' + exp.^var + ']'
+	}
+	
+	/**
+	 * pretty print a *InstanceOf* constraint
+	 */
+	def String prettyPrintInstanceOf(InstanceOf exp) {
+		return 'instanceOf[' + exp.^var + ',' + exp.varType + ']'
+	}
+	
+	def String prettyPrintNotHardCoded(NotHardCoded exp) {
+		return 'notHardCoded[' + exp.^var  + ']'
 	}
 	
 	/**

--- a/br.unb.cic.mcsl/src/br/unb/cic/mcsl/generator/CodeWriterVisitor.xtend
+++ b/br.unb.cic.mcsl/src/br/unb/cic/mcsl/generator/CodeWriterVisitor.xtend
@@ -23,6 +23,8 @@ import br.unb.cic.mcsl.metaCrySL.impl.LiteralSetImpl
 import br.unb.cic.mcsl.metaCrySL.impl.AtomicConstraintImpl
 import java.util.ArrayList
 import br.unb.cic.mcsl.metaCrySL.impl.VariableImpl
+import br.unb.cic.mcsl.metaCrySL.MetaVariable
+import br.unb.cic.mcsl.metaCrySL.impl.MetaVariableImpl
 
 class CodeWriterVisitor extends MetaCrySLSwitch<String> {
 	
@@ -155,6 +157,9 @@ class CodeWriterVisitor extends MetaCrySLSwitch<String> {
 	 */
 	def String prettyPrintLiteralSet(LiteralSet exp) {
 		switch(exp) {
+			MetaVariable: {
+				return prettyPrintMetaVariable(exp)
+			}
 			LiteralSet: {
 				val values = new ArrayList<String>
 				for(obj: exp.values) {
@@ -164,6 +169,13 @@ class CodeWriterVisitor extends MetaCrySLSwitch<String> {
 				return '{' + String.join(',', values) + '}'
 			}
 		}
+	}
+	
+	/**
+	 * pretty print a *MetaVariable* constraint
+	 */
+	def String prettyPrintMetaVariable(MetaVariable exp) {
+		return exp.^var
 	}
 	
 	/**

--- a/br.unb.cic.mcsl/src/br/unb/cic/mcsl/generator/CodeWriterVisitor.xtend
+++ b/br.unb.cic.mcsl/src/br/unb/cic/mcsl/generator/CodeWriterVisitor.xtend
@@ -27,6 +27,7 @@ import br.unb.cic.mcsl.metaCrySL.MetaVariable
 import br.unb.cic.mcsl.metaCrySL.impl.MetaVariableImpl
 import br.unb.cic.mcsl.metaCrySL.impl.BracketsImpl
 import br.unb.cic.mcsl.metaCrySL.impl.FunctionCallImpl
+import br.unb.cic.mcsl.metaCrySL.StringValue
 
 class CodeWriterVisitor extends MetaCrySLSwitch<String> {
 	
@@ -216,6 +217,10 @@ class CodeWriterVisitor extends MetaCrySLSwitch<String> {
 			}
 			IntValue: {
 				val v = value.exp as IntValue
+				return v.value.toString
+			}
+			StringValue: {
+				val v = value.exp as StringValue
 				return v.value.toString
 			}
 		}


### PR DESCRIPTION
Remaining items for Constraints:

- [x] ArithmeticExp
- [x] RelationalExp
- [x] ConjunctionExp
- [x] DisjunctionExp
- [x] ImpliesExp
- [x] NeverTypeOf
- [x] NoCallTo
- [x] CallTo
- [x] NotHardCoded
- [x] Length
- [x] InstanceOf
- [x] InSet
- [x] AtomicConstraint (brackets and function call)
- [x] LiteralSet
- [x] MetaVariable
- [x] Value (string and variable)